### PR TITLE
Removed parameter that does not exist any more

### DIFF
--- a/qtm/discovery.py
+++ b/qtm/discovery.py
@@ -79,7 +79,6 @@ class Discover:
                 protocol_factory,
                 local_addr=(self.ip_address, 0),
                 allow_broadcast=True,
-                reuse_address=True,
             )
 
             LOG.debug("Sending discovery packet on %s", self.ip_address)

--- a/qtm/reboot.py
+++ b/qtm/reboot.py
@@ -14,7 +14,6 @@ async def reboot(ip_address):
         QRebootProtocol,
         local_addr=(ip_address, 0),
         allow_broadcast=True,
-        reuse_address=True,
     )
 
     LOG.info("Sending reboot on %s", ip_address)


### PR DESCRIPTION
Fix for #13 

From the python doc 

> Changed in version 3.8.1: The reuse_address parameter is no longer supported due to security concerns.

> The parameter reuse_address is no longer supported, as using SO_REUSEADDR poses a significant security concern for UDP. Explicitly passing reuse_address=True will raise an exception.