### PR TITLE
When parsing image packet read image data with image size.

### DIFF
--- a/qtm/packet.py
+++ b/qtm/packet.py
@@ -506,7 +506,8 @@ class QRTPacket(object):
             component_position, image_info = QRTPacket._get_exact(
                 RTImage, data, component_position
             )
-            append_components((image_info, data[component_position:-1]))
+            append_components((image_info, data[component_position:component_position + image_info.image_size]))
+            component_position += image_info.image_size
         return components
 
     @ComponentGetter(QRTComponentType.Component3d, RT3DComponent)


### PR DESCRIPTION
Update image packet parsing to be able to parse multple cameras
---
When parsing a image packet with mutiple cameras we cannot just read to end of buffer. We read image size amount of bytes. And 'step forward' accordingly so next cameras information can be read from component_position.