### PR TITLE
Log the instance not the type (fix typo)

### DIFF
--- a/qtm/qrt.py
+++ b/qtm/qrt.py
@@ -363,7 +363,7 @@ async def connect(
     try:
         await protocol.set_version(version)
     except QRTCommandException as exception:
-        LOG.error(Exception)
+        LOG.error(exception)
         return None
     except TypeError as exception:  # TODO: fix test requiring this (test_connect_set_version)
         LOG.error(exception)


### PR DESCRIPTION
Was logging the Exception type and not the instance.

Which would give the user the following log.
`qtm - ERROR - <class 'Exception'>`
Found in #20 