### PR TITLE
Remove obsolete dependencies and update to sphinx 7.3.7 and pytest 8.2.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinxcontrib.asyncio', 'sphinx.ext.autodoc', 'sphinx.ext.githubpages'
+    'sphinx.ext.autodoc', 'sphinx.ext.githubpages'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -69,7 +69,7 @@ release = '2.1.1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -155,7 +155,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,11 +36,11 @@ already streaming data, either live or RT from file.
 QTM RT Protocol
 ---------------
 
-An instance of QRTConnection is returned when qtm_rt.connect_ successfully connects to QTM.
+An instance of QRTConnection is returned when qtm_rt.connect successfully connects to QTM.
 
-Functions marked as coroutines need to be run in a async function and awaited, please see example above.
+Functions marked as async need to be run in a async function and awaited, please see example above.
 
-.. autocofunction:: qtm_rt.connect
+.. autofunction:: qtm_rt.connect
 
 QRTConnection
 ~~~~~~~~~~~~~

--- a/examples/calibration_example.py
+++ b/examples/calibration_example.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import qtm_rt
-from lxml import etree
+import xml.etree.ElementTree as ET
 
 LOG = logging.getLogger("example")
 
@@ -33,16 +33,11 @@ async def setup():
         except Exception as e:
             LOG.error(e)
         else:
-            root = etree.fromstring(cal_response)
-            print(etree.tostring(root, pretty_print=True).decode())
+            root = ET.fromstring(cal_response)
+            print(ET.tostring(root, pretty_print=True).decode())
 
     # tell qtm to stop streaming
     await connection.stream_frames_stop()
 
-    # stop the event loop, thus exiting the run_forever call
-    loop.stop()    
-
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    asyncio.ensure_future(setup())
-    loop.run_forever()
+    asyncio.run(setup())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,5 @@
-black==23.3.0
-pylint==2.17.4
-pytest==7.3.1
-pytest-asyncio==0.21.0
-pytest-mock==3.10.0
-rope==1.8.0
-sphinx==5.3.0
-sphinxcontrib-asyncio==0.3.0
-lxml==4.9.2
-wheel==0.40.0
-twine==4.0.2
+pytest-asyncio==0.23.7
+pytest-mock==3.14.0
+pytest==8.2.2
+sphinx==7.3.7
+twine==5.1.0

--- a/test/qtmprotocol_test.py
+++ b/test/qtmprotocol_test.py
@@ -32,31 +32,35 @@ async def test_await_any_event_timeout(qtmprotocol: QTMProtocol):
 
 
 @pytest.mark.asyncio
-async def test_await_any_event(event_loop, qtmprotocol: QTMProtocol):
+async def test_await_any_event(qtmprotocol: QTMProtocol):
     awaitable = qtmprotocol.await_event(timeout=1)
-    event_loop.call_later(0, lambda: qtmprotocol._on_event(QRTEvent.EventConnected))
+    asyncio.get_running_loop().call_later(0, lambda: qtmprotocol._on_event(QRTEvent.EventConnected))
     result = await awaitable
 
     assert result == QRTEvent.EventConnected
 
 
 @pytest.mark.asyncio
-async def test_await_specific_event(event_loop, qtmprotocol: QTMProtocol):
+async def test_await_specific_event(qtmprotocol: QTMProtocol):
     awaitable = qtmprotocol.await_event(event=QRTEvent.EventConnected, timeout=1)
-    event_loop.call_later(0, lambda: qtmprotocol._on_event(QRTEvent.EventConnected))
+    asyncio.get_running_loop().call_later(
+        0, lambda: qtmprotocol._on_event(QRTEvent.EventConnected)
+    )
     result = await awaitable
 
     assert result == QRTEvent.EventConnected
 
 
 @pytest.mark.asyncio
-async def test_await_event_multiple(event_loop, qtmprotocol: QTMProtocol):
+async def test_await_event_multiple(qtmprotocol: QTMProtocol):
     awaitable = qtmprotocol.await_event(event=QRTEvent.EventConnected, timeout=1)
 
-    event_loop.call_later(
+    asyncio.get_running_loop().call_later(
         0, lambda: qtmprotocol._on_event(QRTEvent.EventConnectionClosed)
     )
-    event_loop.call_later(0.1, lambda: qtmprotocol._on_event(QRTEvent.EventConnected))
+    asyncio.get_running_loop().call_later(
+        0.1, lambda: qtmprotocol._on_event(QRTEvent.EventConnected)
+    )
 
     result = await awaitable
 
@@ -73,7 +77,5 @@ async def test_await_multiple(qtmprotocol: QTMProtocol):
         [awaitable1, awaitable2], return_when=asyncio.FIRST_EXCEPTION
     )
 
-    print(done)
-    
     with pytest.raises(Exception):
         done.pop().result()


### PR DESCRIPTION
Fix issues with requirements-dev.txt, pytest and sphinx.

  * Remove lxml as it fails to build with error `fatal error C1083: Cannot open include file: 'libxml/xpath.h': No such file or directory`. Use built-in xml in `calibration_example.py` instead.
  * Remove black, pylint and rope as they are formatting/lint tools that are not used anywhere in the repository. https://github.com/astral-sh/ruff is all the rage these days anyway.
  * Remove wheel as with Python 3.12 packaging it is setup automatically.
  * Upgrade to twine 5.1.0 while we're at it.

Also upgrade pytest to 8.2.2 to fix deprecation warning:

```
DeprecationWarning: ast.Str is deprecated and will be removed in Python
3.14; use ast.Constant instead
```

Also fix deprecation warning caused by pytest upgrade in several places:

```
PytestDeprecationWarning: test_connect_no_loop
is asynchronous and explicitly requests the "event_loop" fixture.
Asynchronous fixtures and test functions should use
"asyncio.get_running_loop()" instead
```

Also update sphinx to 7.3.7 and fix documentation issues:

  * Remove usage of `sphinxcontrib-asyncio` and rely on sphinx default handling of `async` functions (`autocofunction` changed to `autofunction`).
  * Remove "coroutine" terminology as in Python it is more commonly refered to as async functions.
  * Newer sphinx requires language to be set so set it to `'en'`.
  * Fix warning `html_static_path entry '_static' does not exist` by removing it from config.py.
  * Fix `ERROR: Unknown target name: "qtm_rt.connect".` by removing redundant underscore.