### PR TITLE
Bump version to 3.0.2 and add development instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /qtm_rt.egg-info
 /env
 /env3
+/.venv
 /.idea
 _build
 _static

--- a/README.md
+++ b/README.md
@@ -41,3 +41,37 @@ GetCaptureC3D is not implemented.
 GetCaptureQTM is not implemented.
 
 No support for selecting analog channel.
+
+Development
+-----------
+
+Use the following `bash` commands in sequence to build the distribution and
+documentation:
+
+```
+# Setup build environment
+python -m venv .venv
+source ./.venv/Scripts/activate
+pip install -r requirements-dev.txt
+
+# Run tests
+pytest tests
+
+# Build source tarball and python wheel in dist/
+python -m build
+
+# Build sphinx documentation in docs/_build/html/
+make -C docs html
+
+# Copy build output to gh-pages branch (checkout in separate repository)
+cp -r docs/_build/html/* ../qualisys_python_sdk_gh_pages
+git -C ../qualisys_python_sdk_gh_pages commit -m "Update documentation to version x.y.z"
+git push origin gh-pages
+
+# Upload new version to pypi.org
+twine upload dist/*
+
+# Git tag and manually make release on github
+git tag vx.y.z
+git push --tags
+```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cp -r docs/_build/html/* ../qualisys_python_sdk_gh_pages
 git -C ../qualisys_python_sdk_gh_pages commit -m "Update documentation to version x.y.z"
 git push origin gh-pages
 
-# Upload new version to pypi.org
+# Upload new version to pypi.org (needs API key)
 twine upload dist/*
 
 # Git tag and manually make release on github

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to Qualisys SDK for Python's documentation!
 ===================================================
 
-This document describes the Qualisys SDK for Python version 3.0.1
+This document describes the Qualisys SDK for Python version 3.0.2
 
 **NOTE:** Major versions introduces breaking changes. :ref:`More info...<deprecated_version>`
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+build==1.2.1
 pytest-asyncio==0.23.7
 pytest-mock==3.14.0
 pytest==8.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "3.0.1"
+version = "3.0.2"
 
 setup(
     name="qtm-rt",
@@ -11,7 +11,7 @@ setup(
     download_url="https://github.com/qualisys/qualisys_python_sdk/tarball/{}".format(
         version
     ),
-    author="Martin Gejke",
+    author="Qualisys AB",
     author_email="support@qualisys.com",
     license="MIT",
     packages=["qtm_rt"],


### PR DESCRIPTION
Bump version to 3.0.2 and add `build==1.2.1` dependency including instructions for building, testing and distributing. 