### PR TITLE
Fix RT connection drop when responses race with caller timeouts

### DIFF
--- a/qtm_rt/protocol.py
+++ b/qtm_rt/protocol.py
@@ -132,12 +132,23 @@ class QTMProtocol(asyncio.Protocol):
         """ Received from QTM and route accordingly """
         self._receiver.data_received(data)
 
+    def _pop_next_pending_future(self):
+        # QTM responds in command order, so pair each response with the next
+        # future FIFO. If that future is already done (caller gave up via
+        # asyncio.wait_for timeout), drop the response with it — never call
+        # set_result/set_exception on a done future, that raises
+        # InvalidStateError out of data_received and tears down the transport.
+        if not self.request_queue:
+            return None
+        future = self.request_queue.popleft()
+        if future.done():
+            return None
+        return future
+
     def _deliver_promise(self, data):
-        try:
-            future = self.request_queue.pop()
+        future = self._pop_next_pending_future()
+        if future is not None:
             future.set_result(data)
-        except IndexError:
-            pass
 
     def _on_data(self, packet):
         if self.on_packet is not None:
@@ -171,11 +182,13 @@ class QTMProtocol(asyncio.Protocol):
         LOG.debug("Error: %s", response)
         if self._start_streaming:
             self.set_on_packet(None)
-        try:
-            future = self.request_queue.pop()
+        future = self._pop_next_pending_future()
+        if future is not None:
             future.set_exception(QRTCommandException(response))
-        except IndexError:
-            raise QRTCommandException(response)
+        else:
+            # Unsolicited error (no caller waiting). Raising here would crash
+            # data_received and close the transport, so just log.
+            LOG.warning("Unsolicited error from QTM: %s", response)
 
     def _on_xml(self, response):
         LOG.debug("XML: %s ...", response[: min(len(response), 70)])

--- a/test/qtmprotocol_test.py
+++ b/test/qtmprotocol_test.py
@@ -3,6 +3,7 @@
 """
 
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -79,3 +80,82 @@ async def test_await_multiple(qtmprotocol: QTMProtocol):
 
     with pytest.raises(Exception):
         done.pop().result()
+
+
+def _attach_transport(qtmprotocol: QTMProtocol):
+    qtmprotocol.transport = MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_responses_match_commands_in_fifo_order(qtmprotocol: QTMProtocol):
+    _attach_transport(qtmprotocol)
+
+    future_a = qtmprotocol.send_command("a")
+    future_b = qtmprotocol.send_command("b")
+
+    qtmprotocol._on_command(b"response_a")
+    qtmprotocol._on_command(b"response_b")
+
+    assert await future_a == b"response_a"
+    assert await future_b == b"response_b"
+
+
+@pytest.mark.asyncio
+async def test_late_response_to_cancelled_future_does_not_crash(
+    qtmprotocol: QTMProtocol,
+):
+    _attach_transport(qtmprotocol)
+
+    cancelled_future = qtmprotocol.send_command("save")
+    cancelled_future.cancel()
+
+    later_future = qtmprotocol.send_command("releasecontrol")
+
+    # Late response to "save" is dropped (caller gave up); next response goes to
+    # "releasecontrol". Neither must raise InvalidStateError.
+    qtmprotocol._on_command(b"Measurement saved")
+    qtmprotocol._on_command(b"You are now a regular client")
+
+    assert await later_future == b"You are now a regular client"
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_error_does_not_raise(qtmprotocol: QTMProtocol):
+    _attach_transport(qtmprotocol)
+
+    # Empty request queue. Old behaviour raised QRTCommandException from inside
+    # data_received and killed the transport.
+    qtmprotocol._on_error(b"some unsolicited error")
+
+    # Subsequent commands still work.
+    future = qtmprotocol.send_command("a")
+    qtmprotocol._on_command(b"response_a")
+    assert await future == b"response_a"
+
+
+@pytest.mark.asyncio
+async def test_error_for_cancelled_future_does_not_raise(qtmprotocol: QTMProtocol):
+    _attach_transport(qtmprotocol)
+
+    # Error packet arrives for a command whose caller already gave up.
+    # Must not raise InvalidStateError out of data_received.
+    cancelled_future = qtmprotocol.send_command("save")
+    cancelled_future.cancel()
+
+    qtmprotocol._on_error(b"some error for the cancelled save")
+
+    # Subsequent commands still work — transport was not torn down.
+    future = qtmprotocol.send_command("a")
+    qtmprotocol._on_command(b"response_a")
+    assert await future == b"response_a"
+
+
+@pytest.mark.asyncio
+async def test_error_propagates_to_next_live_caller(qtmprotocol: QTMProtocol):
+    _attach_transport(qtmprotocol)
+
+    future = qtmprotocol.send_command("stop")
+    qtmprotocol._on_error(b"No measurement is running")
+
+    with pytest.raises(QRTCommandException):
+        await future


### PR DESCRIPTION
QTMProtocol._on_error and _deliver_promise had three independent issues that together caused the transport to be torn down on legitimate flows:

1. request_queue.pop() popped the right side while send_command appended to the right, so responses were paired to the most-recently-added future instead of FIFO. Two concurrent commands would deliver each other's responses.

2. set_result/set_exception was called without checking future.done(). When asyncio.wait_for timed out a command, the cancelled future stayed in the queue; the late response then raised InvalidStateError from inside data_received, which asyncio treats as a fatal transport error.

3. _on_error re-raised QRTCommandException when the queue was empty, crashing data_received and closing the connection on any unsolicited error.

Replace both pop sites with _pop_next_pending_future, which uses popleft (FIFO) and returns None when the next queued future is already done — letting the response/error be dropped with it rather than crashing the transport. _on_error now logs a warning instead of raising when the queue is empty.

Adds tests covering FIFO ordering, the cancelled-future race, the unsolicited-error path, and error delivery to the next live caller.