### PR TITLE
Publish examples as GitHub release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,25 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  upload-release-assets:
+    name: Upload release assets
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Package examples and demo data
+        run: |
+          cp qtm_rt/data/Demo.qtm Demo.qtm
+          zip -r qtm-rt-examples.zip examples Demo.qtm
+
+      - name: Upload assets to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" qtm-rt-examples.zip --clobber

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+prune examples
+prune docs
+prune qtm_rt/data

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ https://qualisys.github.io/qualisys_python_sdk/index.html
 Examples
 --------
 
-See the examples folder.
+See the examples folder in the GitHub repository. The examples and demo capture
+file are also published as `qtm-rt-examples.zip` on each GitHub release.
+
+The demo capture file `Demo.qtm` is not included in the PyPI package. Download
+the release asset when running examples that use `--qtm-file`.
 
 Logging
 -------

--- a/examples/asyncio_everything.py
+++ b/examples/asyncio_everything.py
@@ -3,16 +3,12 @@
 import logging
 import asyncio
 import argparse
-import pkg_resources
 
 import qtm_rt
 
 
 logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger("example")
-
-
-QTM_FILE = pkg_resources.resource_filename("qtm_rt", "data/Demo.qtm")
 
 
 class AsyncEnumerate:
@@ -66,7 +62,7 @@ async def choose_qtm_instance(interface):
     return instances[choice].host
 
 
-async def main(interface=None):
+async def main(interface=None, qtm_file="Demo.qtm"):
     """ Main function """
 
     qtm_ip = await choose_qtm_instance(interface)
@@ -89,7 +85,7 @@ async def main(interface=None):
             if result == b"Closing connection":
                 await connection.await_event(qtm_rt.QRTEvent.EventConnectionClosed)
 
-            await connection.load(QTM_FILE)
+            await connection.load(qtm_file)
 
             await connection.start(rtfromfile=True)
 
@@ -159,10 +155,19 @@ def parse_args():
         default="127.0.0.1",
         help="IP of interface to search for QTM instances",
     )
+    parser.add_argument(
+        "--qtm-file",
+        type=str,
+        required=False,
+        default="Demo.qtm",
+        help="QTM file to load for rtfromfile playback",
+    )
 
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    asyncio.get_event_loop().run_until_complete(main(interface=args.ip))
+    asyncio.get_event_loop().run_until_complete(
+        main(interface=args.ip, qtm_file=args.qtm_file)
+    )

--- a/examples/stream_6dof_example.py
+++ b/examples/stream_6dof_example.py
@@ -3,12 +3,10 @@
 """
 
 import asyncio
+import argparse
 import xml.etree.ElementTree as ET
-import pkg_resources
 
 import qtm_rt
-
-QTM_FILE = pkg_resources.resource_filename("qtm_rt", "data/Demo.qtm")
 
 
 def create_body_index(xml_string):
@@ -21,11 +19,13 @@ def create_body_index(xml_string):
 
     return body_to_index
 
+
 def body_enabled_count(xml_string):
     xml = ET.fromstring(xml_string)
     return sum(enabled.text == "true" for enabled in xml.findall("*/Body/Enabled"))
 
-async def main():
+
+async def main(qtm_file):
 
     # Connect to qtm
     connection = await qtm_rt.connect("127.0.0.1")
@@ -45,7 +45,7 @@ async def main():
             await connection.new()
         else:
             # Load qtm file
-            await connection.load(QTM_FILE)
+            await connection.load(qtm_file)
 
             # start rtfromfile
             await connection.start(rtfromfile=True)
@@ -54,7 +54,11 @@ async def main():
     xml_string = await connection.get_parameters(parameters=["6d"])
     body_index = create_body_index(xml_string)
 
-    print("{} of {} 6DoF bodies enabled".format(body_enabled_count(xml_string), len(body_index)))
+    print(
+        "{} of {} 6DoF bodies enabled".format(
+            body_enabled_count(xml_string), len(body_index)
+        )
+    )
 
     wanted_body = "L-frame"
 
@@ -86,6 +90,19 @@ async def main():
     await connection.stream_frames_stop()
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Stream 6DoF data from QTM")
+    parser.add_argument(
+        "--qtm-file",
+        type=str,
+        required=False,
+        default="Demo.qtm",
+        help="QTM file to load for rtfromfile playback",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
+    args = parse_args()
     # Run our asynchronous function until complete
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.get_event_loop().run_until_complete(main(args.qtm_file))


### PR DESCRIPTION
Keeps examples, docs, and demo capture data out of PyPI artifacts. Adds MANIFEST.in, updates example scripts to accept --qtm-file, and packages examples/ plus Demo.qtm into qtm-rt-examples.zip on GitHub Releases.

Validation run locally through .venv:

- python -m pytest test/
- python -m build
- python -m twine check dist/*
- artifact scan confirmed no examples/docs/demo data in wheel or sdist