### PR TITLE
Add CI and Ruff linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    name: Lint and test Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Lint
+        run: python -m ruff check .
+
+      - name: Run tests
+        run: python -m pytest test/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
+      - name: Lint
+        run: python -m ruff check .
+
       - name: Run tests
         run: python -m pytest test/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -36,7 +36,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload release distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: distributions
           path: dist/
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Download release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: distributions
           path: dist/
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Package examples and demo data
         run: |

--- a/examples/qt_example/qt_example.py
+++ b/examples/qt_example/qt_example.py
@@ -70,7 +70,7 @@ class QDiscovery(QObject):
             async for qtm_instance in qtm_rt.Discover(interface):
                 info = qtm_instance.info.decode("utf-8").split(",")[0]
 
-                if not info in self._found_qtms:
+                if info not in self._found_qtms:
                     self.discoveredQTM.emit(info, qtm_instance.host)
                     self._found_qtms[info] = True
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,13 @@ Source = "https://github.com/qualisys/qualisys_python_sdk"
 packages = ["qtm_rt"]
 zip-safe = true
 include-package-data = false
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+# Ruff's default rule set (pyflakes + a subset of pycodestyle), pinned
+# explicitly so a Ruff version bump can't silently change what CI enforces.
+# Broaden deliberately, e.g. add "I" (import sorting) or "UP" (pyupgrade).
+select = ["E4", "E7", "E9", "F"]

--- a/qtm_rt/__init__.py
+++ b/qtm_rt/__init__.py
@@ -1,20 +1,17 @@
 """ Python SDK for QTM """
 
 import logging
-import sys
 import os
 
-PYTHON3 = sys.version_info.major == 3
-
-if PYTHON3:
-    from .discovery import Discover
-    from .reboot import reboot
-    from .qrt import connect, QRTConnection
-    from .protocol import QRTCommandException
-    from .control import TakeControl
-
-from .packet import QRTPacket, QRTEvent
-from .receiver import Receiver
+from .control import TakeControl as TakeControl
+from .discovery import Discover as Discover
+from .packet import QRTEvent as QRTEvent
+from .packet import QRTPacket as QRTPacket
+from .protocol import QRTCommandException as QRTCommandException
+from .qrt import QRTConnection as QRTConnection
+from .qrt import connect as connect
+from .reboot import reboot as reboot
+from .receiver import Receiver as Receiver
 
 # pylint: disable=C0330
 

--- a/qtm_rt/control.py
+++ b/qtm_rt/control.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from .qrt import QRTConnection

--- a/qtm_rt/discovery.py
+++ b/qtm_rt/discovery.py
@@ -75,9 +75,8 @@ class Discover:
         loop = asyncio.get_event_loop()
         if self.first:
 
-            protocol_factory = lambda: QRTDiscoveryProtocol(
-                receiver=self.queue.put_nowait
-            )
+            def protocol_factory():
+                return QRTDiscoveryProtocol(receiver=self.queue.put_nowait)
 
             _, protocol = await loop.create_datagram_endpoint(
                 protocol_factory,

--- a/qtm_rt/protocol.py
+++ b/qtm_rt/protocol.py
@@ -8,8 +8,7 @@ import collections
 import logging
 
 from qtm_rt.packet import QRTPacketType
-from qtm_rt.packet import QRTPacket, QRTEvent
-from qtm_rt.packet import RTheader, RTEvent, RTCommand
+from qtm_rt.packet import RTheader, RTCommand
 from qtm_rt.receiver import Receiver
 
 # pylint: disable=C0330

--- a/qtm_rt/qrt.py
+++ b/qtm_rt/qrt.py
@@ -104,7 +104,7 @@ class QRTConnection(object):
             parameters = ["all"]
         else:
             for parameter in parameters:
-                if not parameter in [
+                if parameter not in [
                     "all",
                     "general",
                     "3d",
@@ -374,7 +374,7 @@ async def connect(
 
 def _validate_components(components):
     for component in components:
-        if not component.lower() in [
+        if component.lower() not in [
             "2d",
             "2dlin",
             "3d",

--- a/qtm_rt/receiver.py
+++ b/qtm_rt/receiver.py
@@ -2,7 +2,7 @@ import logging
 
 from qtm_rt.packet import QRTPacketType
 from qtm_rt.packet import QRTPacket, QRTEvent
-from qtm_rt.packet import RTheader, RTEvent, RTCommand
+from qtm_rt.packet import RTheader, RTEvent
 
 LOG = logging.getLogger("qtm_rt")
 
@@ -17,16 +17,16 @@ class Receiver(object):
         self._received_data += data
         h_size = RTheader.size
         data = self._received_data
-        data_len = len(data);
+        data_len = len(data)
 
         while data_len >= h_size:
             size, type_ = RTheader.unpack_from(data, 0)
             if data_len >= size:
                 self._parse_received(data[h_size:size], type_)
                 data = data[size:]
-                data_len = len(data);
+                data_len = len(data)
             else:
-                break;
+                break
 
         self._received_data = data
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ build==1.2.1
 pytest-asyncio==0.23.7
 pytest-mock==3.14.0
 pytest==8.2.2
+ruff==0.15.15
 sphinx==7.3.7
 twine==6.2.0

--- a/test/qrtconnection_test.py
+++ b/test/qrtconnection_test.py
@@ -316,7 +316,7 @@ async def test_calibrate_fail(a_qrt):
     a_qrt._protocol.receive_response.side_effect = xml
 
     with pytest.raises(QRTCommandException):
-        response = await a_qrt.calibrate()
+        await a_qrt.calibrate()
 
     a_qrt._protocol.send_command.assert_called_once_with("calibrate")
 

--- a/test/qtmprotocol_test.py
+++ b/test/qtmprotocol_test.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from qtm_rt.protocol import QTMProtocol, QRTCommandException
-from qtm_rt.packet import QRTEvent, RTEvent
+from qtm_rt.packet import QRTEvent
 
 # pylint: disable=W0621, C0111, W0212
 


### PR DESCRIPTION
Adds all-branches and PR CI for Python 3.10, 3.11, 3.12, 3.13, and 3.14. Adds Ruff to development requirements, runs lint in CI and release workflows, and fixes existing lint findings so the new checks pass.

Validation run locally through .venv:

- python -m ruff check .
- python -m pytest test/
- python -m build
- python -m twine check dist/*
- artifact scan confirmed no examples/docs/demo data in wheel or sdist