### PR TITLE
Bump release workflow actions for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -33,7 +33,7 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Upload release distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: distributions
           path: dist/
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Download release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: distributions
           path: dist/


### PR DESCRIPTION
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8