### PR TITLE
Land example-asset upload, CI matrix, and Ruff linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    name: Lint and test Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Lint
+        run: python -m ruff check .
+
+      - name: Run tests
+        run: python -m pytest test/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
+      - name: Lint
+        run: python -m ruff check .
+
       - name: Run tests
         run: python -m pytest test/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,25 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  upload-release-assets:
+    name: Upload release assets
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Package examples and demo data
+        run: |
+          cp qtm_rt/data/Demo.qtm Demo.qtm
+          zip -r qtm-rt-examples.zip examples Demo.qtm
+
+      - name: Upload assets to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" qtm-rt-examples.zip --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Package examples and demo data
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+prune examples
+prune docs
+prune qtm_rt/data

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ https://qualisys.github.io/qualisys_python_sdk/index.html
 Examples
 --------
 
-See the examples folder.
+See the examples folder in the GitHub repository. The examples and demo capture
+file are also published as `qtm-rt-examples.zip` on each GitHub release.
+
+The demo capture file `Demo.qtm` is not included in the PyPI package. Download
+the release asset when running examples that use `--qtm-file`.
 
 Logging
 -------

--- a/examples/asyncio_everything.py
+++ b/examples/asyncio_everything.py
@@ -3,16 +3,12 @@
 import logging
 import asyncio
 import argparse
-import pkg_resources
 
 import qtm_rt
 
 
 logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger("example")
-
-
-QTM_FILE = pkg_resources.resource_filename("qtm_rt", "data/Demo.qtm")
 
 
 class AsyncEnumerate:
@@ -66,7 +62,7 @@ async def choose_qtm_instance(interface):
     return instances[choice].host
 
 
-async def main(interface=None):
+async def main(interface=None, qtm_file="Demo.qtm"):
     """ Main function """
 
     qtm_ip = await choose_qtm_instance(interface)
@@ -89,7 +85,7 @@ async def main(interface=None):
             if result == b"Closing connection":
                 await connection.await_event(qtm_rt.QRTEvent.EventConnectionClosed)
 
-            await connection.load(QTM_FILE)
+            await connection.load(qtm_file)
 
             await connection.start(rtfromfile=True)
 
@@ -159,10 +155,19 @@ def parse_args():
         default="127.0.0.1",
         help="IP of interface to search for QTM instances",
     )
+    parser.add_argument(
+        "--qtm-file",
+        type=str,
+        required=False,
+        default="Demo.qtm",
+        help="QTM file to load for rtfromfile playback",
+    )
 
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    asyncio.get_event_loop().run_until_complete(main(interface=args.ip))
+    asyncio.get_event_loop().run_until_complete(
+        main(interface=args.ip, qtm_file=args.qtm_file)
+    )

--- a/examples/qt_example/qt_example.py
+++ b/examples/qt_example/qt_example.py
@@ -70,7 +70,7 @@ class QDiscovery(QObject):
             async for qtm_instance in qtm_rt.Discover(interface):
                 info = qtm_instance.info.decode("utf-8").split(",")[0]
 
-                if not info in self._found_qtms:
+                if info not in self._found_qtms:
                     self.discoveredQTM.emit(info, qtm_instance.host)
                     self._found_qtms[info] = True
         except Exception:

--- a/examples/stream_6dof_example.py
+++ b/examples/stream_6dof_example.py
@@ -3,12 +3,10 @@
 """
 
 import asyncio
+import argparse
 import xml.etree.ElementTree as ET
-import pkg_resources
 
 import qtm_rt
-
-QTM_FILE = pkg_resources.resource_filename("qtm_rt", "data/Demo.qtm")
 
 
 def create_body_index(xml_string):
@@ -21,11 +19,13 @@ def create_body_index(xml_string):
 
     return body_to_index
 
+
 def body_enabled_count(xml_string):
     xml = ET.fromstring(xml_string)
     return sum(enabled.text == "true" for enabled in xml.findall("*/Body/Enabled"))
 
-async def main():
+
+async def main(qtm_file):
 
     # Connect to qtm
     connection = await qtm_rt.connect("127.0.0.1")
@@ -45,7 +45,7 @@ async def main():
             await connection.new()
         else:
             # Load qtm file
-            await connection.load(QTM_FILE)
+            await connection.load(qtm_file)
 
             # start rtfromfile
             await connection.start(rtfromfile=True)
@@ -54,7 +54,11 @@ async def main():
     xml_string = await connection.get_parameters(parameters=["6d"])
     body_index = create_body_index(xml_string)
 
-    print("{} of {} 6DoF bodies enabled".format(body_enabled_count(xml_string), len(body_index)))
+    print(
+        "{} of {} 6DoF bodies enabled".format(
+            body_enabled_count(xml_string), len(body_index)
+        )
+    )
 
     wanted_body = "L-frame"
 
@@ -86,6 +90,19 @@ async def main():
     await connection.stream_frames_stop()
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="Stream 6DoF data from QTM")
+    parser.add_argument(
+        "--qtm-file",
+        type=str,
+        required=False,
+        default="Demo.qtm",
+        help="QTM file to load for rtfromfile playback",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
+    args = parse_args()
     # Run our asynchronous function until complete
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.get_event_loop().run_until_complete(main(args.qtm_file))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,13 @@ Source = "https://github.com/qualisys/qualisys_python_sdk"
 packages = ["qtm_rt"]
 zip-safe = true
 include-package-data = false
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+# Ruff's default rule set (pyflakes + a subset of pycodestyle), pinned
+# explicitly so a Ruff version bump can't silently change what CI enforces.
+# Broaden deliberately, e.g. add "I" (import sorting) or "UP" (pyupgrade).
+select = ["E4", "E7", "E9", "F"]

--- a/qtm_rt/__init__.py
+++ b/qtm_rt/__init__.py
@@ -1,20 +1,17 @@
 """ Python SDK for QTM """
 
 import logging
-import sys
 import os
 
-PYTHON3 = sys.version_info.major == 3
-
-if PYTHON3:
-    from .discovery import Discover
-    from .reboot import reboot
-    from .qrt import connect, QRTConnection
-    from .protocol import QRTCommandException
-    from .control import TakeControl
-
-from .packet import QRTPacket, QRTEvent
-from .receiver import Receiver
+from .control import TakeControl as TakeControl
+from .discovery import Discover as Discover
+from .packet import QRTEvent as QRTEvent
+from .packet import QRTPacket as QRTPacket
+from .protocol import QRTCommandException as QRTCommandException
+from .qrt import QRTConnection as QRTConnection
+from .qrt import connect as connect
+from .reboot import reboot as reboot
+from .receiver import Receiver as Receiver
 
 # pylint: disable=C0330
 

--- a/qtm_rt/control.py
+++ b/qtm_rt/control.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from .qrt import QRTConnection

--- a/qtm_rt/discovery.py
+++ b/qtm_rt/discovery.py
@@ -75,9 +75,8 @@ class Discover:
         loop = asyncio.get_event_loop()
         if self.first:
 
-            protocol_factory = lambda: QRTDiscoveryProtocol(
-                receiver=self.queue.put_nowait
-            )
+            def protocol_factory():
+                return QRTDiscoveryProtocol(receiver=self.queue.put_nowait)
 
             _, protocol = await loop.create_datagram_endpoint(
                 protocol_factory,

--- a/qtm_rt/protocol.py
+++ b/qtm_rt/protocol.py
@@ -8,8 +8,7 @@ import collections
 import logging
 
 from qtm_rt.packet import QRTPacketType
-from qtm_rt.packet import QRTPacket, QRTEvent
-from qtm_rt.packet import RTheader, RTEvent, RTCommand
+from qtm_rt.packet import RTheader, RTCommand
 from qtm_rt.receiver import Receiver
 
 # pylint: disable=C0330

--- a/qtm_rt/qrt.py
+++ b/qtm_rt/qrt.py
@@ -104,7 +104,7 @@ class QRTConnection(object):
             parameters = ["all"]
         else:
             for parameter in parameters:
-                if not parameter in [
+                if parameter not in [
                     "all",
                     "general",
                     "3d",
@@ -374,7 +374,7 @@ async def connect(
 
 def _validate_components(components):
     for component in components:
-        if not component.lower() in [
+        if component.lower() not in [
             "2d",
             "2dlin",
             "3d",

--- a/qtm_rt/receiver.py
+++ b/qtm_rt/receiver.py
@@ -2,7 +2,7 @@ import logging
 
 from qtm_rt.packet import QRTPacketType
 from qtm_rt.packet import QRTPacket, QRTEvent
-from qtm_rt.packet import RTheader, RTEvent, RTCommand
+from qtm_rt.packet import RTheader, RTEvent
 
 LOG = logging.getLogger("qtm_rt")
 
@@ -17,16 +17,16 @@ class Receiver(object):
         self._received_data += data
         h_size = RTheader.size
         data = self._received_data
-        data_len = len(data);
+        data_len = len(data)
 
         while data_len >= h_size:
             size, type_ = RTheader.unpack_from(data, 0)
             if data_len >= size:
                 self._parse_received(data[h_size:size], type_)
                 data = data[size:]
-                data_len = len(data);
+                data_len = len(data)
             else:
-                break;
+                break
 
         self._received_data = data
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ build==1.2.1
 pytest-asyncio==0.23.7
 pytest-mock==3.14.0
 pytest==8.2.2
+ruff==0.15.15
 sphinx==7.3.7
 twine==6.2.0

--- a/test/qrtconnection_test.py
+++ b/test/qrtconnection_test.py
@@ -316,7 +316,7 @@ async def test_calibrate_fail(a_qrt):
     a_qrt._protocol.receive_response.side_effect = xml
 
     with pytest.raises(QRTCommandException):
-        response = await a_qrt.calibrate()
+        await a_qrt.calibrate()
 
     a_qrt._protocol.send_command.assert_called_once_with("calibrate")
 

--- a/test/qtmprotocol_test.py
+++ b/test/qtmprotocol_test.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from qtm_rt.protocol import QTMProtocol, QRTCommandException
-from qtm_rt.packet import QRTEvent, RTEvent
+from qtm_rt.packet import QRTEvent
 
 # pylint: disable=W0621, C0111, W0212
 


### PR DESCRIPTION
Brings the modernization stack [pr2-release-example-assets](https://github.com/qualisys/qualisys_python_sdk/tree/pr2-release-example-assets) + [pr3-add-ci-and-ruff](https://github.com/qualisys/qualisys_python_sdk/tree/pr3-add-ci-and-ruff) onto master. Both were merged into their stacked bases (#51, #52) but the final master-bound PR never opened, so this work has been sitting unmerged.

Cherry-picks instead of a stack merge — pr3's bottom commit duplicates #50's packaging work which is already on master, so a direct merge conflicts. The Node-24 actions bump (`9259493`) overlaps with #55 and was reduced from 8/8 to 3/3 lines on the cherry-pick.

Contents:
- `.github/workflows/ci.yml` — Python 3.10–3.14 matrix on PRs and master pushes
- `.github/workflows/release.yml` — adds Ruff linting and `qtm-rt-examples.zip` release-asset upload (zips `examples/` + `Demo.qtm`)
- `MANIFEST.in` — controls sdist contents
- `pyproject.toml` — Ruff ruleset
- `qtm_rt/__init__.py` — drop the dead `PYTHON3` Python-2 import gate
- Ruff style cleanup across `qtm_rt/*` and `test/*`
- Examples (`asyncio_everything.py`, `stream_6dof_example.py`) refactored for modern asyncio + the new asset path

Tested: all 81 tests pass locally.